### PR TITLE
Fix PHP 8.4 compatibility issues

### DIFF
--- a/Block/Adminhtml/Widget/Preview/ProductsList.php
+++ b/Block/Adminhtml/Widget/Preview/ProductsList.php
@@ -66,9 +66,9 @@ class ProductsList extends \Magento\CatalogWidget\Block\Product\ProductsList imp
         return [];
     }
 
-    public function getCacheKey(): array
+    public function getCacheKey(): string
     {
-        return [];
+        return '';
     }
 
     /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# 1.4.1
+### Fixed
+- Fix getCacheKey() return type from array to string matching parent contract
+
 # 1.4.0
 ## Updated
 - Update composer JSON making the module installable for Magento Opensource also


### PR DESCRIPTION
## Summary

Fix PHP 8.4 compatibility issue in ProductsList.php:

- **getCacheKey()**: change return type from array to string to match the parent AbstractBlock contract, preventing type mismatch issues

## Suggested release

@rhoerr This could be tagged as 1.4.1 (patch release).