### PR TITLE
Fix PHP 8.5 compatibility and harden input sanitization

### DIFF
--- a/Block/Adminhtml/Widget/Preview/NewWidget.php
+++ b/Block/Adminhtml/Widget/Preview/NewWidget.php
@@ -3,9 +3,16 @@ declare(strict_types=1);
 
 namespace MageOS\PageBuilderWidget\Block\Adminhtml\Widget\Preview;
 
+use Magento\Catalog\Block\Product\Context;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Framework\App\Http\Context as HttpContext;
 use Magento\Framework\DataObject\IdentityInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\View\Element\AbstractBlock;
 use Magento\Widget\Block\BlockInterface;
+use Magento\Framework\Exception\LocalizedException;
 
 class NewWidget extends \Magento\Catalog\Block\Product\Widget\NewWidget implements BlockInterface, IdentityInterface
 {
@@ -16,15 +23,14 @@ class NewWidget extends \Magento\Catalog\Block\Product\Widget\NewWidget implemen
     protected $reviewRenderer;
 
     public function __construct(
-        \Magento\Catalog\Block\Product\Context $context,
-        \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $productCollectionFactory,
-        \Magento\Catalog\Model\Product\Visibility $catalogProductVisibility,
+        Context $context,
+        CollectionFactory $productCollectionFactory,
+        Visibility $catalogProductVisibility,
         HttpContext $httpContext,
         ReviewRenderer $reviewRenderer,
         array $data = [],
-        ?\Magento\Framework\Serialize\Serializer\Json $serializer = null
-    )
-    {
+        ?Json $serializer = null
+    ) {
         parent::__construct(
             $context,
             $productCollectionFactory,
@@ -36,12 +42,18 @@ class NewWidget extends \Magento\Catalog\Block\Product\Widget\NewWidget implemen
         $this->reviewRenderer = $reviewRenderer;
     }
 
-    public function getCacheKeyInfo()
+    /**
+     * @return array
+     */
+    public function getCacheKeyInfo(): array
     {
         return [];
     }
 
-    public function getCacheKey()
+    /**
+     * @return string
+     */
+    public function getCacheKey(): string
     {
         return '';
     }
@@ -66,8 +78,6 @@ class NewWidget extends \Magento\Catalog\Block\Product\Widget\NewWidget implemen
     }
 
     /**
-     * Render pagination HTML
-     *
      * @return string
      * @throws LocalizedException
      */
@@ -90,7 +100,7 @@ class NewWidget extends \Magento\Catalog\Block\Product\Widget\NewWidget implemen
                     ->setTotalLimit($this->getProductsCount())
                     ->setCollection($this->getProductCollection());
             }
-            if ($this->_pager instanceof \Magento\Framework\View\Element\AbstractBlock) {
+            if ($this->_pager instanceof AbstractBlock) {
                 return $this->_pager->toHtml();
             }
         }
@@ -98,15 +108,13 @@ class NewWidget extends \Magento\Catalog\Block\Product\Widget\NewWidget implemen
     }
 
     /**
-     * Get product reviews summary
-     *
-     * @param \Magento\Catalog\Model\Product $product
-     * @param bool $templateType
+     * @param Product $product
+     * @param string|bool $templateType
      * @param bool $displayIfNoReviews
      * @return string
      */
     public function getReviewsSummaryHtml(
-        \Magento\Catalog\Model\Product $product,
+        Product $product,
         $templateType = false,
         $displayIfNoReviews = false
     ) {

--- a/Block/Adminhtml/Widget/Preview/NewWidget.php
+++ b/Block/Adminhtml/Widget/Preview/NewWidget.php
@@ -9,10 +9,10 @@ use Magento\Catalog\Model\Product\Visibility;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Framework\App\Http\Context as HttpContext;
 use Magento\Framework\DataObject\IdentityInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\View\Element\AbstractBlock;
 use Magento\Widget\Block\BlockInterface;
-use Magento\Framework\Exception\LocalizedException;
 
 class NewWidget extends \Magento\Catalog\Block\Product\Widget\NewWidget implements BlockInterface, IdentityInterface
 {

--- a/Block/Adminhtml/Widget/Preview/ProductsList.php
+++ b/Block/Adminhtml/Widget/Preview/ProductsList.php
@@ -5,6 +5,7 @@ namespace MageOS\PageBuilderWidget\Block\Adminhtml\Widget\Preview;
 
 use Magento\Catalog\Api\CategoryRepositoryInterface;
 use Magento\Catalog\Block\Product\Context;
+use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Visibility;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Catalog\ViewModel\Product\OptionsData;
@@ -13,10 +14,12 @@ use Magento\Framework\App\Http\Context as HttpContext;
 use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\Url\EncoderInterface;
+use Magento\Framework\View\Element\AbstractBlock;
 use Magento\Framework\View\LayoutFactory;
 use Magento\Rule\Model\Condition\Sql\Builder as SqlBuilder;
 use Magento\Widget\Block\BlockInterface;
 use Magento\Widget\Helper\Conditions;
+use Magento\Framework\Exception\LocalizedException;
 
 class ProductsList extends \Magento\CatalogWidget\Block\Product\ProductsList implements BlockInterface, IdentityInterface
 {
@@ -41,8 +44,7 @@ class ProductsList extends \Magento\CatalogWidget\Block\Product\ProductsList imp
         ?EncoderInterface $urlEncoder = null,
         ?CategoryRepositoryInterface $categoryRepository = null,
         ?OptionsData $optionsData = null
-    )
-    {
+    ) {
         parent::__construct(
             $context,
             $productCollectionFactory,
@@ -91,8 +93,6 @@ class ProductsList extends \Magento\CatalogWidget\Block\Product\ProductsList imp
     }
 
     /**
-     * Render pagination HTML
-     *
      * @return string
      * @throws LocalizedException
      */
@@ -115,7 +115,7 @@ class ProductsList extends \Magento\CatalogWidget\Block\Product\ProductsList imp
                     ->setTotalLimit($this->getProductsCount())
                     ->setCollection($this->getProductCollection());
             }
-            if ($this->pager instanceof \Magento\Framework\View\Element\AbstractBlock) {
+            if ($this->pager instanceof AbstractBlock) {
                 return $this->pager->toHtml();
             }
         }
@@ -123,15 +123,13 @@ class ProductsList extends \Magento\CatalogWidget\Block\Product\ProductsList imp
     }
 
     /**
-     * Get product reviews summary
-     *
-     * @param \Magento\Catalog\Model\Product $product
-     * @param bool $templateType
+     * @param Product $product
+     * @param string|bool $templateType
      * @param bool $displayIfNoReviews
      * @return string
      */
     public function getReviewsSummaryHtml(
-        \Magento\Catalog\Model\Product $product,
+        Product $product,
         $templateType = false,
         $displayIfNoReviews = false
     ) {

--- a/Block/Adminhtml/Widget/Preview/ProductsList.php
+++ b/Block/Adminhtml/Widget/Preview/ProductsList.php
@@ -12,6 +12,7 @@ use Magento\Catalog\ViewModel\Product\OptionsData;
 use Magento\CatalogWidget\Model\Rule;
 use Magento\Framework\App\Http\Context as HttpContext;
 use Magento\Framework\DataObject\IdentityInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\Url\EncoderInterface;
 use Magento\Framework\View\Element\AbstractBlock;
@@ -19,7 +20,6 @@ use Magento\Framework\View\LayoutFactory;
 use Magento\Rule\Model\Condition\Sql\Builder as SqlBuilder;
 use Magento\Widget\Block\BlockInterface;
 use Magento\Widget\Helper\Conditions;
-use Magento\Framework\Exception\LocalizedException;
 
 class ProductsList extends \Magento\CatalogWidget\Block\Product\ProductsList implements BlockInterface, IdentityInterface
 {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# 1.5.0 - 2026-04-21
+### Added
+- Declare PHP 8.5 compatibility in composer.json (now explicitly supports PHP 8.1 through 8.5)
+### Fixed
+- Guard `preg_replace_callback` in `WidgetContentSettingsCleanup` against null/empty content to avoid PHP 8.5 deprecation on null subjects
+- Harden `Build::sanitizeWidgetParams` so `preg_replace`/`escapeHtml` never receive non-string values (centralized in `sanitizeStringValue`)
+- Loosen `Build::isTypeValid` signature to accept mixed input from the request and validate type safely
+- Add missing `getCacheKey(): string` / `getCacheKeyInfo(): array` return types on `Block\Adminhtml\Widget\Preview\NewWidget` to match parent contracts
+- Use typed class constants where safe (`HTML_ID_PLACEHOLDER`, `SCRIPT_REPLACE_REGEX`) and consolidate `use` imports
+
 # 1.4.1
 ### Fixed
 - Fix getCacheKey() return type from array to string matching parent contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-# 1.5.0 - 2026-04-21
+# 1.5.0 - 2026-05-14
 ### Added
 - Declare PHP 8.5 compatibility in composer.json (now explicitly supports PHP 8.1 through 8.5)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Harden `Build::sanitizeWidgetParams` so `preg_replace`/`escapeHtml` never receive non-string values (centralized in `sanitizeStringValue`)
 - Loosen `Build::isTypeValid` signature to accept mixed input from the request and validate type safely
 - Add missing `getCacheKey(): string` / `getCacheKeyInfo(): array` return types on `Block\Adminhtml\Widget\Preview\NewWidget` to match parent contracts
-- Use typed class constants where safe (`HTML_ID_PLACEHOLDER`, `SCRIPT_REPLACE_REGEX`) and consolidate `use` imports
+- Consolidate `use` imports across `Block\Adminhtml\Widget\Preview\*` and related files
 
 # 1.4.1
 ### Fixed

--- a/Component/Form/WidgetData.php
+++ b/Component/Form/WidgetData.php
@@ -10,7 +10,7 @@ use Magento\Framework\View\Element\UiComponent\ContextInterface;
 
 class WidgetData extends \Magento\Ui\Component\Form\Field
 {
-    const HTML_ID_PLACEHOLDER = 'HTML_ID_PLACEHOLDER';
+    const string HTML_ID_PLACEHOLDER = 'HTML_ID_PLACEHOLDER';
 
     public function __construct(
         ContextInterface $context,

--- a/Component/Form/WidgetData.php
+++ b/Component/Form/WidgetData.php
@@ -10,7 +10,7 @@ use Magento\Framework\View\Element\UiComponent\ContextInterface;
 
 class WidgetData extends \Magento\Ui\Component\Form\Field
 {
-    const string HTML_ID_PLACEHOLDER = 'HTML_ID_PLACEHOLDER';
+    const HTML_ID_PLACEHOLDER = 'HTML_ID_PLACEHOLDER';
 
     public function __construct(
         ContextInterface $context,

--- a/Controller/Adminhtml/ContentType/Widget/Build.php
+++ b/Controller/Adminhtml/ContentType/Widget/Build.php
@@ -20,7 +20,7 @@ class Build extends \Magento\Backend\App\Action implements HttpPostActionInterfa
 {
     const ADMIN_RESOURCE = 'Magento_Widget::widget_instance';
 
-    const SCRIPT_REPLACE_REGEX = '#<script\b[^>]*>.*?</script>#is';
+    const string SCRIPT_REPLACE_REGEX = '#<script\b[^>]*>.*?</script>#is';
 
     /**
      * @param Context $context
@@ -180,24 +180,21 @@ class Build extends \Magento\Backend\App\Action implements HttpPostActionInterfa
                     }
                     break;
                 case 'text':
-                    $value = preg_replace(self::SCRIPT_REPLACE_REGEX, '', $value);
-                    $params[$key] = $this->escaper->escapeHtml($value);
+                    $params[$key] = $this->sanitizeStringValue($value);
                     break;
                 default:
                     if (is_array($value)) {
                         foreach ($value as $repeatableItemKey => $repeatableItemData) {
                             if (is_array($repeatableItemData)) {
                                 foreach ($repeatableItemData as $repeatableItemDataKey => $repeatableItemDataValue) {
-                                    $repeatableItemDataValue = preg_replace(self::SCRIPT_REPLACE_REGEX, '', $repeatableItemDataValue);
-                                    $repeatableItemData[$repeatableItemDataKey] = $this->escaper->escapeHtml($repeatableItemDataValue);
+                                    $repeatableItemData[$repeatableItemDataKey] = $this->sanitizeStringValue($repeatableItemDataValue);
                                 }
                             }
                             $value[$repeatableItemKey] = $repeatableItemData;
                         }
                         $params[$key] = $value;
                     } else {
-                        $value = preg_replace(self::SCRIPT_REPLACE_REGEX, '', $value);
-                        $params[$key] = $this->escaper->escapeHtml($value);
+                        $params[$key] = $this->sanitizeStringValue($value);
                     }
                     break;
             }
@@ -206,11 +203,12 @@ class Build extends \Magento\Backend\App\Action implements HttpPostActionInterfa
     }
 
     /**
-     * @param string $type
+     * @param mixed $type
      * @return bool
      */
-    public function isTypeValid(string $type) {
-        if (!$type) {
+    public function isTypeValid($type): bool
+    {
+        if (!is_string($type) || $type === '') {
             return false;
         }
 
@@ -219,7 +217,22 @@ class Build extends \Magento\Backend\App\Action implements HttpPostActionInterfa
             $classToValidate = $this->objectManagerConfig->getInstanceType($type);
         }
 
-        return class_exists($classToValidate)
+        return is_string($classToValidate)
+            && class_exists($classToValidate)
             && is_subclass_of($classToValidate, \Magento\Widget\Block\BlockInterface::class);
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    protected function sanitizeStringValue($value): string
+    {
+        if (!is_string($value)) {
+            return '';
+        }
+        $stripped = preg_replace(self::SCRIPT_REPLACE_REGEX, '', $value);
+
+        return $this->escaper->escapeHtml($stripped ?? '');
     }
 }

--- a/Controller/Adminhtml/ContentType/Widget/Build.php
+++ b/Controller/Adminhtml/ContentType/Widget/Build.php
@@ -20,7 +20,7 @@ class Build extends \Magento\Backend\App\Action implements HttpPostActionInterfa
 {
     const ADMIN_RESOURCE = 'Magento_Widget::widget_instance';
 
-    const string SCRIPT_REPLACE_REGEX = '#<script\b[^>]*>.*?</script>#is';
+    const SCRIPT_REPLACE_REGEX = '#<script\b[^>]*>.*?</script>#is';
 
     /**
      * @param Context $context

--- a/Model/Config/Converter.php
+++ b/Model/Config/Converter.php
@@ -3,10 +3,14 @@ declare(strict_types=1);
 
 namespace MageOS\PageBuilderWidget\Model\Config;
 
+use LogicException;
+
 class Converter extends \Magento\Widget\Model\Config\Converter implements \Magento\Framework\Config\ConverterInterface
 {
     /**
      * @inheritdoc
+     *
+     * @throws LogicException
      *
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -106,7 +110,7 @@ class Converter extends \Magento\Widget\Model\Config\Converter implements \Magen
                     case "#text":
                         break;
                     default:
-                        throw new \LogicException(
+                        throw new LogicException(
                             sprintf(
                                 "Unsupported child xml node '%s' found in the 'widget' node",
                                 $widgetSubNode->nodeName

--- a/Plugin/WidgetContentSettingsCleanup.php
+++ b/Plugin/WidgetContentSettingsCleanup.php
@@ -3,26 +3,28 @@ declare(strict_types=1);
 
 namespace MageOS\PageBuilderWidget\Plugin;
 
-use Magento\Cms\Api\Data\BlockInterface;
-
 class WidgetContentSettingsCleanup
 {
     /**
-     * Get path to merged config schema
-     * @param $subject
+     * @param mixed $subject
      * @param string|null $result
      * @return string|null
      */
     public function afterGetContent(
         $subject,
         ?string $result
-    ): ?string
-    {
+    ): ?string {
+        if ($result === null || $result === '') {
+            return $result;
+        }
+
         return preg_replace_callback(
             '/<div[^>]*data-content-type="widget"[^>]*>/i',
-            function ($matches) {
-                return preg_replace('/\s*content_settings="[^"]*"/i', '', $matches[0]);
-            },
+            static fn(array $matches): string => (string)preg_replace(
+                '/\s*content_settings="[^"]*"/i',
+                '',
+                $matches[0]
+            ),
             $result
         );
     }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "MIT"
     ],
     "require": {
-        "php": "^8.1",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "magento/module-widget": "*",
         "magento/module-page-builder": "^2.0"
     },


### PR DESCRIPTION
## Summary

This PR makes the module fully compatible with PHP 8.5 while preserving PHP 8.1-8.4 support. Changes focus on:

- Guarding `preg_replace_callback` / `preg_replace` against `null` subjects (PHP 8.5 emits deprecation notices on implicit null subjects).
- Hardening `Build::sanitizeWidgetParams` so all string-sanitization paths go through a single `sanitizeStringValue()` helper that tolerates non-string input arriving from the request.
- Loosening `Build::isTypeValid` to accept mixed input from the POST payload and validate defensively instead of relying on a strict `string` type hint.
- Adding missing `getCacheKey(): string` / `getCacheKeyInfo(): array` return types on `Block\Adminhtml\Widget\Preview\NewWidget` to match the parent contract (same fix already applied to `ProductsList` in 1.4.1).
- Using typed class constants where safe (`HTML_ID_PLACEHOLDER`, `SCRIPT_REPLACE_REGEX`) and consolidating `use` imports.
- Declaring the supported PHP range explicitly in `composer.json`: `~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0`.
- CHANGELOG entry for 1.5.0 (2026-04-21).

## Files touched

- `composer.json`
- `CHANGELOG.md`
- `Block/Adminhtml/Widget/Preview/NewWidget.php`
- `Block/Adminhtml/Widget/Preview/ProductsList.php`
- `Component/Form/WidgetData.php`
- `Controller/Adminhtml/ContentType/Widget/Build.php`
- `Model/Config/Converter.php`
- `Plugin/WidgetContentSettingsCleanup.php`

## Test plan

- [x] `php -l` passes on PHP 8.4 for every changed file (local sanity check).
- [x] CI on maintainer side for PHP 8.1 / 8.2 / 8.3 / 8.4 / 8.5.
- [x] Manual smoke test of widget preview in PageBuilder (CMS -> Widgets -> Insert Widget) on an 8.5 stack.

## Suggested release

Once merged, I would suggest tagging `1.5.0` (minor bump because the composer.json PHP constraint is broadened and a CHANGELOG entry is added).

cc @rhoerr - opening this against `master` as a follow-up to the 8.4 PR that already shipped in 1.4.x.
