### PR TITLE
Fix previewTemplates xml node merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# 1.4.2
+### Fixed
+- Fix previewTemplates xml node merge adding reference to xml config reader
+
 # 1.4.1
 ### Fixed
 - Fix getCacheKey() return type from array to string matching parent contract

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -2,6 +2,18 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Magento\Widget\Model\Config\Converter"
                 type="MageOS\PageBuilderWidget\Model\Config\Converter" />
+    <type name="Magento\Widget\Model\Config\Reader">
+        <arguments>
+            <argument name="idAttributes" xsi:type="array">
+                <item name="/widgets/widget" xsi:type="string">id</item>
+                <item name="/widgets/widget/parameters/parameter" xsi:type="string">name</item>
+                <item name="/widgets/widget/parameters/parameter/options/option" xsi:type="string">name</item>
+                <item name="/widgets/widget/containers/container" xsi:type="string">name</item>
+                <item name="/widgets/widget/containers/container/template" xsi:type="string">name</item>
+                <item name="/widgets/widget/previewTemplates/previewTemplate" xsi:type="string">name</item>
+            </argument>
+        </arguments>
+    </type>
     <virtualType name="DefaultWYSIWYGValidator">
         <arguments>
             <argument name="allowedAttributes" xsi:type="array">


### PR DESCRIPTION
The previewTemplates/previewTemplate node specification for the XML configuration was missing.
This prevents the specification of multiple previewTemplate nodes within modules that extend widgets by adding different adminhtml previews for different widget templates (if there is more than one).